### PR TITLE
Bump Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,10 +29,10 @@
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- version properties -->
-    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
-    <hydrator.version>2.3.0-SNAPSHOT</hydrator.version>
+    <cdap.version>6.8.0</cdap.version>
+    <hydrator.version>2.10.0</hydrator.version>
     <commons.csv.version>1.6</commons.csv.version>
-    <hadoop.version>2.8.0</hadoop.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <spark2.version>2.3.1</spark2.version>
     <netty.version>4.1.16.Final</netty.version>
     <netty-http.version>1.3.0</netty-http.version>
@@ -374,6 +374,12 @@
       <artifactId>hydrator-test</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/src/main/java/io/cdap/plugin/snowflake/common/util/QueryUtil.java
+++ b/src/main/java/io/cdap/plugin/snowflake/common/util/QueryUtil.java
@@ -22,7 +22,7 @@ package io.cdap.plugin.snowflake.common.util;
 public class QueryUtil {
 
   // Matches "limit <number>". Also "limit $$$$" and "limit ''" which means unlimited in Snowflake.
-  private static final String LIMIT_PATTERN = "(?i)LIMIT (''|\\$\\$\\$\\$|\\d+)";
+  private static final String LIMIT_PATTERN = "(?i)LIMIT (NULL|''|\\$\\$\\$\\$|\\d+)";
   private static final String LIMIT_STRING = "limit %s";
 
   private QueryUtil() {

--- a/src/test/java/io/cdap/plugin/snowflake/common/BaseSnowflakeTest.java
+++ b/src/test/java/io/cdap/plugin/snowflake/common/BaseSnowflakeTest.java
@@ -17,6 +17,7 @@
 package io.cdap.plugin.snowflake.common;
 
 import io.cdap.cdap.etl.mock.test.HydratorTestBase;
+import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.snowflake.Constants;
 import io.cdap.plugin.snowflake.common.client.SnowflakeAccessorTest;
 import io.cdap.plugin.snowflake.source.batch.SnowflakeBatchSourceConfig;
@@ -24,6 +25,7 @@ import io.cdap.plugin.snowflake.source.batch.SnowflakeBatchSourceConfigBuilder;
 import net.snowflake.client.jdbc.SnowflakeBasicDataSource;
 import org.junit.Assume;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.internal.AssumptionViolatedException;
 import org.junit.rules.TestName;
@@ -54,6 +56,9 @@ import java.sql.SQLException;
 public abstract class BaseSnowflakeTest extends HydratorTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(SnowflakeAccessorTest.class);
+
+  @ClassRule
+  public static final TestConfiguration TEST_CONFIG = new TestConfiguration("explore.enabled", false);
 
   protected static final String ACCOUNT_NAME = System.getProperty("snowflake.test.account.name");
   protected static final String DATABASE = System.getProperty("snowflake.test.database");

--- a/src/test/java/io/cdap/plugin/snowflake/common/util/SchemaHelperTest.java
+++ b/src/test/java/io/cdap/plugin/snowflake/common/util/SchemaHelperTest.java
@@ -64,15 +64,16 @@ public class SchemaHelperTest {
 
   @Test
   public void testGetSchemaFromSnowflakeUnknownType() throws IOException {
+    String importQuery = "SELECT * FROM someTable";
     MockFailureCollector collector = new MockFailureCollector(MOCK_STAGE);
     SnowflakeSourceAccessor snowflakeAccessor = Mockito.mock(SnowflakeSourceAccessor.class);
 
     List<SnowflakeFieldDescriptor> sample = new ArrayList<>();
     sample.add(new SnowflakeFieldDescriptor("field1", -1000, false));
 
-    Mockito.when(snowflakeAccessor.describeQuery(null)).thenReturn(sample);
+    Mockito.when(snowflakeAccessor.describeQuery(importQuery)).thenReturn(sample);
 
-    SchemaHelper.getSchema(snowflakeAccessor, null, collector, null);
+    SchemaHelper.getSchema(snowflakeAccessor, null, collector, importQuery);
 
     ValidationAssertions.assertValidationFailed(
       collector, Collections.singletonList(SnowflakeBatchSourceConfig.PROPERTY_SCHEMA));
@@ -80,6 +81,7 @@ public class SchemaHelperTest {
 
   @Test
   public void testGetSchemaFromSnowflake() throws IOException {
+    String importQuery = "SELECT * FROM someTable";
     MockFailureCollector collector = new MockFailureCollector(MOCK_STAGE);
     SnowflakeSourceAccessor snowflakeAccessor = Mockito.mock(SnowflakeSourceAccessor.class);
 
@@ -137,9 +139,9 @@ public class SchemaHelperTest {
       Schema.Field.of("field132", Schema.decimalOf(38))
     );
 
-    Mockito.when(snowflakeAccessor.describeQuery(null)).thenReturn(sample);
+    Mockito.when(snowflakeAccessor.describeQuery(importQuery)).thenReturn(sample);
 
-    Schema actual = SchemaHelper.getSchema(snowflakeAccessor, null, collector, null);
+    Schema actual = SchemaHelper.getSchema(snowflakeAccessor, null, collector, importQuery);
 
     Assert.assertTrue(collector.getValidationFailures().isEmpty());
     Assert.assertEquals(expected, actual);

--- a/src/test/java/io/cdap/plugin/snowflake/source/batch/SnowflakeMapToRecordTransformerTest.java
+++ b/src/test/java/io/cdap/plugin/snowflake/source/batch/SnowflakeMapToRecordTransformerTest.java
@@ -50,8 +50,8 @@ public class SnowflakeMapToRecordTransformerTest {
     row.put("COLUMN_CHARACTER", "2");
     row.put("COLUMN_STRING", "text_115");
     row.put("COLUMN_TEXT", "text_116");
-    row.put("COLUMN_BINARY", "text_117");
-    row.put("COLUMN_VARBINARY", "text_118");
+    row.put("COLUMN_BINARY", "746578745f313137");
+    row.put("COLUMN_VARBINARY", "746578745f313138");
     row.put("COLUMN_BOOLEAN", "true");
     row.put("COLUMN_DATE", "2019-01-01");
     row.put("COLUMN_DATETIME", "2019-01-01T01:01:01+00:00");


### PR DESCRIPTION
 - Exclude log4j
 - Disable CDAP explore
 - Bump hadoop to 2.10.2
 - Bump CDAP and hydrator to 6.8
 - Fix previously failing unit tests
   - QueryUtilTest: Fix regex to also accept `limit NULL` per [snowflake documentation](https://docs.snowflake.com/en/sql-reference/constructs/limit.html)
   - SnowflakeMapToRecordTransformerTest: Changed byte fields to be hex-encoded
   - SchemaHelperTest: Add import queries to ensure getSchema doesn't return null