### PR TITLE
[PLUGIN-1682] [cherrypicked]Fixed null output schema in case of macros for connection properties

### DIFF
--- a/src/main/java/io/cdap/plugin/snowflake/common/util/SchemaHelper.java
+++ b/src/main/java/io/cdap/plugin/snowflake/common/util/SchemaHelper.java
@@ -58,7 +58,7 @@ public class SchemaHelper {
 
   public static Schema getSchema(SnowflakeBatchSourceConfig config, FailureCollector collector) {
     if (!config.canConnect()) {
-      return null;
+      return getParsedSchema(config.getSchema());
     }
 
     SnowflakeSourceAccessor snowflakeSourceAccessor = new SnowflakeSourceAccessor(config);
@@ -69,11 +69,7 @@ public class SchemaHelper {
                                  FailureCollector collector, String importQuery) {
     try {
       if (!Strings.isNullOrEmpty(schema)) {
-        try {
-          return Schema.parseJson(schema);
-        } catch (IOException | IllegalStateException e) {
-          throw new SchemaParseException(e);
-        }
+        return getParsedSchema(schema);
       }
       return Strings.isNullOrEmpty(importQuery) ? null : getSchema(snowflakeAccessor, importQuery);
     } catch (SchemaParseException e) {
@@ -82,6 +78,17 @@ public class SchemaHelper {
         .withStacktrace(e.getStackTrace())
         .withConfigProperty(SnowflakeBatchSourceConfig.PROPERTY_SCHEMA);
       return null;
+    }
+  }
+
+  private static Schema getParsedSchema(String schema) {
+    if (Strings.isNullOrEmpty(schema)) {
+      return null;
+    }
+    try {
+      return Schema.parseJson(schema);
+    } catch (IOException | IllegalStateException e) {
+      throw new SchemaParseException(e);
     }
   }
 

--- a/src/test/java/io/cdap/plugin/snowflake/common/util/SchemaHelperTest.java
+++ b/src/test/java/io/cdap/plugin/snowflake/common/util/SchemaHelperTest.java
@@ -25,6 +25,7 @@ import io.cdap.plugin.snowflake.source.batch.SnowflakeSourceAccessor;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+
 import java.io.IOException;
 import java.sql.Types;
 import java.util.ArrayList;
@@ -143,5 +144,38 @@ public class SchemaHelperTest {
 
     Assert.assertTrue(collector.getValidationFailures().isEmpty());
     Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testGetSchemaWhenMacroIsEnabled() {
+    Schema expected = Schema.recordOf("test",
+            Schema.Field.of("test_field", Schema.nullableOf(Schema.of(Schema.Type.LONG)))
+    );
+
+    SnowflakeBatchSourceConfig mockConfig = Mockito.mock(SnowflakeBatchSourceConfig.class);
+    Mockito.when(mockConfig.canConnect()).thenReturn(false);
+    Mockito.when(mockConfig.getSchema()).thenReturn(expected.toString());
+
+    MockFailureCollector collector = new MockFailureCollector(MOCK_STAGE);
+    Schema actual = SchemaHelper.getSchema(mockConfig, collector);
+
+    Assert.assertTrue(collector.getValidationFailures().isEmpty());
+    Assert.assertEquals(expected, actual);
+
+  }
+
+  @Test
+  public void testGetSchemaWhenMacroIsEnabledSchemaIsNull() {
+
+    SnowflakeBatchSourceConfig mockConfig = Mockito.mock(SnowflakeBatchSourceConfig.class);
+    Mockito.when(mockConfig.canConnect()).thenReturn(false);
+    Mockito.when(mockConfig.getSchema()).thenReturn(null);
+
+    MockFailureCollector collector = new MockFailureCollector(MOCK_STAGE);
+    Schema actual = SchemaHelper.getSchema(mockConfig, collector);
+
+    Assert.assertTrue(collector.getValidationFailures().isEmpty());
+    Assert.assertNull(actual);
+
   }
 }


### PR DESCRIPTION
Cherrypicked from [PR #15](https://github.com/data-integrations/snowflake-plugins/pull/15)