### PR TITLE
[PLUGIN-1731]Added fix for Oauth

### DIFF
--- a/src/main/java/io/cdap/plugin/snowflake/common/client/SnowflakeAccessor.java
+++ b/src/main/java/io/cdap/plugin/snowflake/common/client/SnowflakeAccessor.java
@@ -111,6 +111,10 @@ public class SnowflakeAccessor {
     if (config.getOauth2Enabled()) {
       String accessToken = OAuthUtil.getAccessTokenByRefreshToken(HttpClients.createDefault(), config);
       dataSource.setOauthToken(accessToken);
+      // The recommend way to pass token is in the password when you use the driver with connection pool.
+      // This is also a mandatory field, so adding the same.
+      // Refer https://github.com/snowflakedb/snowflake-jdbc/issues/1175
+      dataSource.setPassword(accessToken);
     } else if (config.getKeyPairEnabled()) {
       dataSource.setUser(config.getUsername());
 


### PR DESCRIPTION
https://cdap.atlassian.net/browse/PLUGIN-1731
Added fix for Oauth.
While using Oauth mechanism with source plugin, pipeline was failing due to a null check on snowflake jdbc driver side code for password, even though it is not getting used. Passing access token value to avoid the failure.