### PR TITLE
PLUGIN-1896: Add Get Schema button to Named Table option

### DIFF
--- a/src/main/java/io/cdap/plugin/snowflake/source/batch/ImportQueryType.java
+++ b/src/main/java/io/cdap/plugin/snowflake/source/batch/ImportQueryType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Cask Data, Inc.
+ * Copyright © 2025 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/widgets/Snowflake-batchsource.json
+++ b/widgets/Snowflake-batchsource.json
@@ -58,7 +58,17 @@
         {
           "widget-type": "textbox",
           "label": "Table Name",
-          "name": "tableName"
+          "name": "tableName",
+          "plugin-function": {
+            "label": "Get Schema",
+            "widget": "outputSchema",
+            "output-property": "schema",
+            "omit-properties": [
+              {
+                "name": "schema"
+              }
+            ]
+          }
         },
         {
           "widget-type": "textarea",


### PR DESCRIPTION
[PLUGIN-1896](https://cdap.atlassian.net/browse/PLUGIN-1896)

**Issue:** Get Schema button was not appearing if `Named Table` was selected as the radio button for the Import Query Type.

**Fix:** Added the plugin function to get the output schemaa for the named table 

####

**[BEFORE]**
<img width="1769" alt="image" src="https://github.com/user-attachments/assets/4901f81b-7816-44d6-b9d5-57c21c48ee26" />


**[AFTER]**
<img width="1782" alt="image" src="https://github.com/user-attachments/assets/f13fb08c-c7e4-4d77-b5d9-743907be6ff7" />


[PLUGIN-1896]: https://cdap.atlassian.net/browse/PLUGIN-1896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ