### PR TITLE
[🍒] [PLUGIN-1954] Update Snowflake JDBC driver to 4.0.2 and adapt API changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <powermock.version>1.7.4</powermock.version>
     <guice.version>4.0</guice.version>
     <opencsv.version>2.4</opencsv.version>
-    <snowflake-jdbc.version>3.14.4</snowflake-jdbc.version>
+    <snowflake-jdbc.version>4.0.2</snowflake-jdbc.version>
   </properties>
 
   <repositories>

--- a/src/main/java/io/cdap/plugin/snowflake/common/BaseSnowflakeConfig.java
+++ b/src/main/java/io/cdap/plugin/snowflake/common/BaseSnowflakeConfig.java
@@ -286,7 +286,7 @@ public class BaseSnowflakeConfig extends PluginConfig {
       && !containsMacro(PROPERTY_PASSWORD) && !containsMacro(PROPERTY_WAREHOUSE)
       && !containsMacro(PROPERTY_ROLE) && !containsMacro(PROPERTY_CLIENT_ID)
       && !containsMacro(PROPERTY_CLIENT_SECRET) && !containsMacro(PROPERTY_REFRESH_TOKEN)
-      && !containsMacro(PROPERTY_PRIVATE_KEY));
+      && !containsMacro(PROPERTY_PRIVATE_KEY) && !containsMacro(PROPERTY_PASSPHRASE));
   }
 
   protected void validateConnection(FailureCollector collector) {
@@ -308,7 +308,7 @@ public class BaseSnowflakeConfig extends PluginConfig {
 
       // TODO: for oauth2
       if (Boolean.TRUE.equals(keyPairEnabled)) {
-        failure.withConfigProperty(PROPERTY_PRIVATE_KEY);
+        failure.withConfigProperty(PROPERTY_PRIVATE_KEY).withConfigProperty(PROPERTY_PASSPHRASE);
       } else {
         failure.withConfigProperty(PROPERTY_PASSWORD);
       }

--- a/src/main/java/io/cdap/plugin/snowflake/common/SnowflakeErrorType.java
+++ b/src/main/java/io/cdap/plugin/snowflake/common/SnowflakeErrorType.java
@@ -22,7 +22,7 @@ import io.cdap.cdap.api.exception.ErrorType;
 import io.cdap.cdap.api.exception.ErrorUtils;
 import io.cdap.cdap.api.exception.ProgramFailureException;
 import io.cdap.plugin.snowflake.common.util.DocumentUrlUtil;
-import net.snowflake.client.jdbc.ErrorCode;
+import net.snowflake.client.api.exception.ErrorCode;
 
 import java.sql.SQLException;
 import java.util.Arrays;

--- a/src/main/java/io/cdap/plugin/snowflake/common/client/SnowflakeAccessor.java
+++ b/src/main/java/io/cdap/plugin/snowflake/common/client/SnowflakeAccessor.java
@@ -28,7 +28,7 @@ import io.cdap.plugin.snowflake.common.SnowflakeErrorType;
 import io.cdap.plugin.snowflake.common.exception.ConnectionTimeoutException;
 import io.cdap.plugin.snowflake.common.util.DocumentUrlUtil;
 import io.cdap.plugin.snowflake.common.util.QueryUtil;
-import net.snowflake.client.jdbc.SnowflakeBasicDataSource;
+import net.snowflake.client.internal.api.implementation.datasource.SnowflakeBasicDataSource;
 import org.apache.http.impl.client.HttpClients;
 
 import java.io.BufferedWriter;
@@ -154,10 +154,10 @@ public class SnowflakeAccessor {
 
     if (Boolean.TRUE.equals(config.getOauth2Enabled())) {
       String accessToken = OAuthUtil.getAccessTokenByRefreshToken(HttpClients.createDefault(), config);
-      dataSource.setOauthToken(accessToken);
-      // The recommend way to pass token is in the password when you use the driver with connection pool.
-      // This is also a mandatory field, so adding the same.
-      // Refer https://github.com/snowflakedb/snowflake-jdbc/issues/1175
+      // In JDBC 4.x, setOauthToken() was removed. The recommended approach is to explicitly
+      // set the authenticator to "oauth" and pass the access token as the password.
+      // Migration guide: https://docs.snowflake.com/en/developer-guide/jdbc/jdbc-migration
+      dataSource.setAuthenticator("oauth");
       dataSource.setPassword(accessToken);
     } else if (Boolean.TRUE.equals(config.getKeyPairEnabled())) {
       dataSource.setUser(config.getUsername());

--- a/src/main/java/io/cdap/plugin/snowflake/sink/batch/SnowflakeSinkAccessor.java
+++ b/src/main/java/io/cdap/plugin/snowflake/sink/batch/SnowflakeSinkAccessor.java
@@ -19,7 +19,8 @@ package io.cdap.plugin.snowflake.sink.batch;
 import io.cdap.plugin.snowflake.common.SnowflakeErrorType;
 import io.cdap.plugin.snowflake.common.client.SnowflakeAccessor;
 import io.cdap.plugin.snowflake.common.util.DocumentUrlUtil;
-import net.snowflake.client.jdbc.SnowflakeConnection;
+import net.snowflake.client.api.connection.SnowflakeConnection;
+import net.snowflake.client.api.connection.UploadStreamConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.InputStream;
@@ -52,9 +53,10 @@ public class SnowflakeSinkAccessor extends SnowflakeAccessor {
     LOG.info("Uploading file '{}' to table stage", filename);
 
     try (Connection connection = dataSource.getConnection()) {
+      UploadStreamConfig uploadConfig = UploadStreamConfig.builder().setDestPrefix(null).setCompressData(true).build();
       connection.unwrap(SnowflakeConnection.class).uploadStream(stageDir,
-                                                                null,
-                                                                inputStream, filename, true);
+                                                                filename,
+                                                                inputStream, uploadConfig);
     } catch (SQLException e) {
       String errorReason = String.format("Unable to compress '%s' and upload data to destination stage '%s'. For " +
         "more details, see %s", filename, stageDir, DocumentUrlUtil.getSupportedDocumentUrl());

--- a/src/main/java/io/cdap/plugin/snowflake/source/batch/SnowflakeSourceAccessor.java
+++ b/src/main/java/io/cdap/plugin/snowflake/source/batch/SnowflakeSourceAccessor.java
@@ -24,7 +24,8 @@ import io.cdap.plugin.snowflake.common.client.SnowflakeAccessor;
 import io.cdap.plugin.snowflake.common.util.DocumentUrlUtil;
 import io.cdap.plugin.snowflake.common.util.QueryUtil;
 import io.cdap.plugin.snowflake.common.util.SchemaHelper;
-import net.snowflake.client.jdbc.SnowflakeConnection;
+import net.snowflake.client.api.connection.DownloadStreamConfig;
+import net.snowflake.client.api.connection.SnowflakeConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.IOException;
@@ -140,8 +141,9 @@ public class SnowflakeSourceAccessor extends SnowflakeAccessor {
    */
   public CSVReader buildCsvReader(String stageSplit) {
     try (Connection connection = dataSource.getConnection()) {
+      DownloadStreamConfig downloadStreamConfig = DownloadStreamConfig.builder().setDecompress(true).build();
       InputStream downloadStream = connection.unwrap(SnowflakeConnection.class)
-        .downloadStream("@~", stageSplit, true);
+              .downloadStream("@~", stageSplit, downloadStreamConfig);
       InputStreamReader inputStreamReader = new InputStreamReader(downloadStream);
       return new CSVReader(inputStreamReader, ',', '"', escapeChar);
     } catch (SQLException e) {

--- a/src/test/java/io/cdap/plugin/snowflake/common/BaseSnowflakeTest.java
+++ b/src/test/java/io/cdap/plugin/snowflake/common/BaseSnowflakeTest.java
@@ -22,7 +22,7 @@ import io.cdap.plugin.snowflake.Constants;
 import io.cdap.plugin.snowflake.common.client.SnowflakeAccessorTest;
 import io.cdap.plugin.snowflake.source.batch.SnowflakeBatchSourceConfig;
 import io.cdap.plugin.snowflake.source.batch.SnowflakeBatchSourceConfigBuilder;
-import net.snowflake.client.jdbc.SnowflakeBasicDataSource;
+import net.snowflake.client.internal.api.implementation.datasource.SnowflakeBasicDataSource;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;


### PR DESCRIPTION
# [PLUGIN-1954]
Bumps `snowflake-jdbc.version` from `3.14.4` to `4.0.2`.

The migration to Snowflake JDBC 4.0.2 requires updating downloadStream and uploadStream calls to use the new DownloadStreamConfig and UploadStreamConfig builders

1. Download Stream: Explicit Decompression
Previously, the decompression behavior was controlled by a trailing boolean. This is now encapsulated within `DownloadStreamConfig`.

2. Upload Stream: Encapsulated Configuration
The legacy 5-argument `uploadStream` has been simplified. Metadata like destination prefixes and compression settings are now moved into `UploadStreamConfig`.

3. OAuth2 Authentication Update
 -- Removed deprecated setOauthToken() method
 --  Added explicit setAuthenticator("oauth") call before setting password

4. Configuration Validation Enhancement
 -- Added passphrase validation for key-pair authentication

https://docs.snowflake.com/en/developer-guide/jdbc/jdbc-migration#stream-upload-and-download-changes

[PLUGIN-1954]: https://cdap.atlassian.net/browse/PLUGIN-1954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ